### PR TITLE
Fixed tntnet.xml for out-of-tree builds

### DIFF
--- a/tntnet.xml.in
+++ b/tntnet.xml.in
@@ -140,6 +140,6 @@
   <!-- <maxBackgroundTasks>5</maxBackgroundTasks> -->
 
   <compPath>
-    <entry>@top_srcdir@/webapp/.libs</entry>
+    <entry>@top_builddir@/webapp/.libs</entry>
   </compPath>
 </tntnet>


### PR DESCRIPTION
Sadly this doesn't make the server run from an out-of-tree build directory. There seem to be other problems that need to be resolved.
